### PR TITLE
Flexible version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='singer-tools',
-      version='0.3.2',
+      version='0.3.3',
       description='Tools for working with Singer.io Taps and Targets',
       author='Stitch',
       url='http://singer.io',

--- a/singertools/release.py
+++ b/singertools/release.py
@@ -60,7 +60,6 @@ def parse_version_number(lines):
 
 
 def find_version_number():
-    candidates = []
     try:
         with open('setup.py') as setup:
             return parse_version_number(setup)

--- a/singertools/release.py
+++ b/singertools/release.py
@@ -33,25 +33,41 @@ def git_check_status():
 def git_push():
     git('push')
 
-def find_version_number():
+
+class VersionNumberException(Exception):
+    pass
+
+def parse_version_number(lines):
     candidates = []
-    with open('setup.py') as setup:
-        for line in setup:
-            match = re.match(r'^\s+version=\'(\d\.\d\.\d)\',', line)
+    for line in lines:
+        match_sq = re.match(r'^\s+version=\'(\d+\.\d+\.\d+\w*)\',', line)
+        match_dq = re.match(r'^\s+version=\"(\d+\.\d+\.\d+\w*)\",', line)
+        for match in [match_sq, match_dq]:
             if match:
                 candidates.append(match.group(1))
     if len(candidates) == 1:
         return candidates[0]
     elif not candidates:
-        print("I couldn't find the version number in setup.py. " +
-              "Please make sure there's a line that looks like " +
-              "'version='x.x.x','.")
-        exit(1)
+        raise VersionNumberException(
+            "I couldn't find the version number in setup.py. " +
+            "Please make sure there's a line that looks like " +
+            "'version='...','.")
     else:
-        print("I found multiple candidates for the version number in " +
-              "setup.py. Please make sure there's exactly one line that " +
-              "looks like 'version=x.x.x,'.")
+        raise VersionNumberException(
+            "I found multiple candidates for the version number in " +
+            "setup.py. Please make sure there's exactly one line that " +
+            "looks like 'version=x.x.x,'.")
+
+
+def find_version_number():
+    candidates = []
+    try:
+        with open('setup.py') as setup:
+            return parse_version_number(setup)
+    except VersionNumberException as exc:
+        print(exc)
         exit(1)
+
 
 def main():
     version = find_version_number()

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,29 @@
+import unittest
+from singertools.release import parse_version_number
+
+class TestRelease(unittest.TestCase):
+
+    def test_parse_version_number_simple(self):
+        version = parse_version_number("""
+          setup(name='singer-python',
+                version='1.2.3',
+                description='Singer.io utility library')
+        """.splitlines())
+        self.assertEqual('1.2.3', version)
+
+    def test_parse_version_number_alpha(self):
+        version = parse_version_number("""
+          setup(name='singer-python',
+                version='1.2.3a1',
+                description='Singer.io utility library')
+        """.splitlines())
+        self.assertEqual('1.2.3a1', version)        
+
+    def test_parse_version_number_double_quotes(self):
+        version = parse_version_number('''
+          setup(name="singer-python",
+                version="1.2.3a1",
+                description="Singer.io utility library")
+        '''.splitlines())
+        self.assertEqual('1.2.3a1', version)        
+        


### PR DESCRIPTION
Make singer-release be more flexible when parsing version numbers

* Allow single and double quotes (`'1.2.3'` and `"1.2.3"`)
* Allow characters after patch (`'1.2.3a1'`)