### PR TITLE
Add tool to diff jsonl files

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,62 @@ Note that `singer-release` _does not_ change the version number. You must
 edit `setup.py` and set the version number manually and commit the change
 before running `singer-release`.
 
+diff-jsonl
+----------
+
+When you make a change to a tap, you want some confidence that you're not introducing a regression. So, it's helpful to be able to diff the output of tap jobs. The `diff-jsonl` tool diffs two JSONL files, such as those produced by a tap:
+
+```diff
+$ diff-jsonl data-on-master.jsonl data-on-branch.jsonl
+*** data-on-master.jsonl
+
+--- data-on-branch.jsonl
+
+***************
+
+*** 833,839 ****
+
+          "billingStreet": null,
+          "city": null,
+          "company": "Corgis Ltd",
+!         "contactCompany": 7,
+          "cookies": null,
+          "country": null,
+          "createdAt": "2016-03-10T18:47:20Z",
+--- 833,839 ----
+
+          "billingStreet": null,
+          "city": null,
+          "company": "Corgis Ltd",
+!         "contactCompany": "7",
+          "cookies": null,
+          "country": null,
+          "createdAt": "2016-03-10T18:47:20Z",
+***************
+
+*** 870,877 ****
+
+          "lastName": "Karstendick",
+          "lastReferredEnrollment": null,
+          "lastReferredVisit": null,
+!         "leadPartitionId": 1,
+!         "leadPerson": 7,
+          "leadRevenueCycleModelId": null,
+          "leadRevenueStageId": null,
+          "leadRole": null,
+--- 870,877 ----
+
+          "lastName": "Karstendick",
+          "lastReferredEnrollment": null,
+          "lastReferredVisit": null,
+!         "leadPartitionId": "1",
+!         "leadPerson": "7",
+          "leadRevenueCycleModelId": null,
+          "leadRevenueStageId": null,
+          "leadRole": null,
+***************
+```
+
 License
 -------
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   post:
-    - pylint singertools -d missing-docstring,locally-disabled
+    - pylint singertools -d missing-docstring,locally-disabled,unsupported-assignment-operation

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='singer-tools',
-      version='0.3.3',
+      version='0.4.0',
       description='Tools for working with Singer.io Taps and Targets',
       author='Stitch',
       url='http://singer.io',
@@ -21,6 +21,7 @@ setup(name='singer-tools',
           singer-infer-schema=singertools.infer_schema:main
           singer-check-tap=singertools.check_tap:main
           singer-release=singertools.release:main
+          diff-jsonl=singertools.diff_jsonl:main
       ''',
       include_package_data=True,
 )

--- a/singertools/diff_jsonl.py
+++ b/singertools/diff_jsonl.py
@@ -1,0 +1,30 @@
+import json
+import sys
+import argparse
+import difflib
+
+def load_jsonl_file(file_path):
+    with open(file_path) as f:
+        lines = [json.loads(line) for line in f.readlines()]
+    return lines
+
+def prettify(lines):
+    pretty_lines = [json.dumps(line, sort_keys=True, indent=4) for line in lines]
+    pretty_lines = sorted(pretty_lines)
+    return '\n'.join(pretty_lines)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file1")
+    parser.add_argument("file2")
+    args = parser.parse_args()
+
+    lines1 = load_jsonl_file(args.file1)
+    lines2 = load_jsonl_file(args.file2)
+
+    pretty_lines1 = prettify(lines1)
+    pretty_lines2 = prettify(lines2)
+
+
+    for line in difflib.context_diff(pretty_lines1.splitlines(), pretty_lines2.splitlines(), fromfile=args.file1, tofile=args.file2):
+        print(line)

--- a/singertools/diff_jsonl.py
+++ b/singertools/diff_jsonl.py
@@ -1,11 +1,10 @@
 import json
-import sys
 import argparse
 import difflib
 
 def load_jsonl_file(file_path):
-    with open(file_path) as f:
-        lines = [json.loads(line) for line in f.readlines()]
+    with open(file_path) as file_obj:
+        lines = [json.loads(line) for line in file_obj.readlines()]
     return lines
 
 def prettify(lines):
@@ -26,5 +25,6 @@ def main():
     pretty_lines2 = prettify(lines2)
 
 
-    for line in difflib.context_diff(pretty_lines1.splitlines(), pretty_lines2.splitlines(), fromfile=args.file1, tofile=args.file2):
+    for line in difflib.context_diff(pretty_lines1.splitlines(), pretty_lines2.splitlines(),
+                                     fromfile=args.file1, tofile=args.file2):
         print(line)


### PR DESCRIPTION
Today I made a change to the data-typing in a Tap, and I wanted a way to ensure that I changed only what I intended to. I didn't have a good tool for diffing JSONL files, so I built one:

```diff
(singer-tools) vagrant@joshua1:/opt/code/singer-tools$ diff-jsonl ../tap-marketo/data-on-master.out ../tap-marketo/data-on-branch.out
*** ../tap-marketo/data-on-master.out

--- ../tap-marketo/data-on-branch.out

***************

*** 833,839 ****

          "billingStreet": null,
          "city": null,
          "company": "Corgis Ltd",
!         "contactCompany": 7,
          "cookies": null,
          "country": null,
          "createdAt": "2016-03-10T18:47:20Z",
--- 833,839 ----

          "billingStreet": null,
          "city": null,
          "company": "Corgis Ltd",
!         "contactCompany": "7",
          "cookies": null,
          "country": null,
          "createdAt": "2016-03-10T18:47:20Z",
***************

*** 870,877 ****

          "lastName": "Karstendick",
          "lastReferredEnrollment": null,
          "lastReferredVisit": null,
!         "leadPartitionId": 1,
!         "leadPerson": 7,
          "leadRevenueCycleModelId": null,
          "leadRevenueStageId": null,
          "leadRole": null,
--- 870,877 ----

          "lastName": "Karstendick",
          "lastReferredEnrollment": null,
          "lastReferredVisit": null,
!         "leadPartitionId": "1",
!         "leadPerson": "7",
          "leadRevenueCycleModelId": null,
          "leadRevenueStageId": null,
          "leadRole": null,
***************
```