### PR TITLE
format: "date-time" under an ["object", "null"] type yields AttributeError

### DIFF
--- a/singertools/check_tap.py
+++ b/singertools/check_tap.py
@@ -18,7 +18,6 @@ import singer
 from terminaltables import AsciiTable
 
 
-
 WORKING_DIR_NAME = 'singer-check-tap-data'
 
 
@@ -31,7 +30,9 @@ def extend_with_default(validator_class):
 
         for prop, subschema in properties.items():
             if "format" in subschema:
-                if subschema['format'] == 'date-time' and instance.get(prop) is not None:
+                if subschema['format'] == 'date-time' and \
+                   instance is not None and \
+                   instance.get(prop) is not None:
                     try:
                         datetime.utcfromtimestamp(rfc3339_to_timestamp(instance[prop]))
                     except Exception:


### PR DESCRIPTION
given a schema:

```json
{
  "type": "object",
  "properties": {
    "example": {
      "type": ["null", "object"],
      "properties": {
        "date": {
          "type": "string",
          "format": "date-time"
        }
      }
    }
  }
}
```

and input data:

```json
{
  "example": null
}
```

running `singer-check-tap` on these inputs yields:

```
File "/Users/connor/.pyenv/versions/3.6.0/envs/tap-selligent/lib/python3.6/site-packages/singertools/check_tap.py", line 34, in set_defaults
    if subschema['format'] == 'date-time' and instance.get(prop) is not None:
AttributeError: 'NoneType' object has no attribute 'get'
```

this checks that instance is not None separately to avoid this AttributeError