### PR TITLE
Support for multiple input streams and additional args for output

### DIFF
--- a/singertools/infer_schema.py
+++ b/singertools/infer_schema.py
@@ -30,7 +30,7 @@ def add_observations(acc, path, data):
         # If the string parses as a date, add an observation that its a date
         try:
             data = dateutil.parser.parse(data)
-        except dateutil.parser.ParserError:
+        except (dateutil.parser.ParserError, OverflowError):
             data = None
         if data:
             add_observation(acc, path + ["date"])

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,4 +1,9 @@
 import unittest
+import sys
+import tempfile
+import os
+import io
+import json
 
 import singertools.infer_schema as infer
 
@@ -9,16 +14,15 @@ rec2 = {"name": "Joe", "age": 55, "money": 5.87, "is_cool": True, "birthday": "0
 class InferSchema(unittest.TestCase):
 
     def test_add_observations(self):
-        infer.add_observations([], rec)
-        self.assertEqual(infer.OBSERVED_TYPES,
+        obs1 = infer.add_observations({}, [], rec)
+        self.assertEqual(obs1,
                          {'object': {'age': {'integer': True},
                                      'name': {'string': True},
                                      'is_cool': {'boolean': True},
                                      'money': {'number': True},
                                      'birthday': {'date': True}}})
-        infer.OBSERVED_TYPES = {}
-        infer.add_observations([], rec2)
-        self.assertEqual(infer.OBSERVED_TYPES,
+        obs2 = infer.add_observations({}, [], rec2)
+        self.assertEqual(obs2,
                          {'object': {'money': {'number': True},
                                      'info': {'object': {'test': {'integer': True},
                                                          'hello': {'string': True},
@@ -30,9 +34,8 @@ class InferSchema(unittest.TestCase):
 
 
     def test_to_json_schema(self):
-        infer.OBSERVED_TYPES = {}
-        infer.add_observations([], rec)
-        result = infer.to_json_schema(infer.OBSERVED_TYPES)
+        obs1 = infer.add_observations({}, [], rec)
+        result = infer.to_json_schema(obs1)
         self.assertEqual(result,
                          {'properties': {'money': {'type': ['null', 'string'], 'format': 'singer.decimal'},
                                          'birthday': {'type': ['null', 'string'], 'format': 'date-time'},
@@ -40,10 +43,8 @@ class InferSchema(unittest.TestCase):
                                          'age': {'type': ['null', 'integer']},
                                          'name': {'type': ['null', 'string']}},
                           'type': ['null', 'object']})
-
-        infer.OBSERVED_TYPES = {}
-        infer.add_observations([], rec2)
-        result = infer.to_json_schema(infer.OBSERVED_TYPES)
+        obs2 = infer.add_observations({}, [], rec2)
+        result = infer.to_json_schema(obs2)
         self.assertEqual(result,
                          {'properties': {'money': {'format': 'singer.decimal', 'type': ['null', 'string']},
                                          'info': {'properties': {'test': {'type': ['null', 'integer']},
@@ -54,3 +55,29 @@ class InferSchema(unittest.TestCase):
                                          'is_cool': {'type': ['null', 'boolean']},
                                          'birthday': {'format': 'date-time', 'type': ['null', 'string']},
                                          'age': {'type': ['null', 'integer']}}, 'type': ['null', 'object']})
+
+    def test_infer_end_to_end(self):
+        rec_messages = [{"type": "RECORD", "stream": "one", "record": {"test": "value"}},
+                        {"type": "RECORD", "stream": "one", "record": {"another_key": 1.1}},
+                        {"type": "RECORD", "stream": "two", "record": {"another": 1}},
+                        {"type": "RECORD", "stream": "three", "record": {"hello": True}}]
+
+        one_schema = {'type': ['null', 'object'], 'properties': {'test': {'type': ['null', 'string']},
+                                                                 'another_key': {'type': ['null', 'string'], 'format': 'singer.decimal'}}}
+        two_schema = {'type': ['null', 'object'], 'properties': {'another': {'type': ['null', 'integer']}}}
+        three_schema = {'type': ['null', 'object'], 'properties': {'hello': {'type': ['null', 'boolean']}}}
+
+        with tempfile.TemporaryDirectory() as td:
+            messages = [json.dumps(r) for r in rec_messages]
+            infer.infer_schemas(messages, td)
+            
+            self.assertEqual(len(os.listdir(td)), 3)
+
+            one = json.load(open(os.path.join(td, 'one.inferred.json')))
+            self.assertEqual(one, one_schema)
+            two = json.load(open(os.path.join(td, 'two.inferred.json')))
+            self.assertEqual(two, two_schema)
+            three = json.load(open(os.path.join(td, 'three.inferred.json')))
+            self.assertEqual(three, three_schema)
+            
+            


### PR DESCRIPTION
# Description of change

Adds argparser for 2 args: 

* `--records` for a list of record inputs (for testing). This defaults to STDIN if not passed.
* `--out-dir` for a directory to output schemas to.

Refactors code to support multiple input streams and disambiguate via the `"stream"` key of the `RecordMessage`. When records are given to the tool for multiple streams, the `--out-dir` arg will send each inferred schema to the provided directory.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
