### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 conflicts with the tap it's operating on.
 
 1. Create and activate a virtualenv
-2. `pip install -e .` (for developing `singer-tools`) or `pip install singer-tools` (for running `singer-tools`)
+2. `pip install -e .` (for developing `singer-tools`) or `pip install git+https://github.com/singer-io/singer-tools@master` (for running `singer-tools`)
 3. Run via `<virtualenv>/bin/<singer-tool>`, e.g. `<virtualenv>/bin/singer-check-tap`.
 
 Tools


### PR DESCRIPTION
# Description of change

* PyPi repo is 2 years stale, with last update in 2018: https://pypi.org/project/singer-tools/#history
* Repo has updates within last 2 months. 
* Better to give pip install instructions directly from git, at least until pypi publish is automated.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
