### PR TITLE
Create out-dir if missing during infer schema

### DIFF
--- a/singertools/infer_schema.py
+++ b/singertools/infer_schema.py
@@ -109,6 +109,9 @@ def infer_schemas(record_inputs, out_dir):
 
     for stream, observations in streams.items():
         if out_dir:
+            if not os.path.exists(out_dir):
+                os.makedirs(out_dir)
+
             out_file = os.path.join(out_dir, "{}.inferred.json".format(stream))
             with open(out_file, 'w') as file:
                 file.write(json.dumps(to_json_schema(observations), indent=2))


### PR DESCRIPTION
# Description of change
I've ran this so many times when the directory was not created yet. I figured adding this idempotent operation (checks if exists, if not make dir) was simple enough to add. Tested it.
Error before:
```
cat ~/git/tap-jira/tap-jira-output-no-transformer.out | /usr/local/share/virtualenvs/singer-tools/bin/singer-infer-schema --out-dir /tmp/tap-jira-schemas
Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/singer-tools/bin/singer-infer-schema", line 33, in <module>
    sys.exit(load_entry_point('singer-tools', 'console_scripts', 'singer-infer-schema')())
  File "/Users/aerlich/git/singer-tools/singertools/infer_schema.py", line 137, in main
    infer_schemas(parsed.records, parsed.out_dir)
  File "/Users/aerlich/git/singer-tools/singertools/infer_schema.py", line 113, in infer_schemas
    with open(out_file, 'w') as file:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tap-jira-schemas/projects.inferred.json'
```

Success after:
```
cat ~/git/tap-jira/tap-jira-output-no-transformer.out | /usr/local/share/virtualenvs/singer-tools/bin/singer-infer-schema --out-dir /tmp/tap-jira-schemas

ls /tmp/tap-jira-schemas/
changelogs.inferred.json          projects.inferred.json
components.inferred.json          resolutions.inferred.json
issue_comments.inferred.json      roles.inferred.json
issue_transitions.inferred.json   users.inferred.json
issues.inferred.json              versions.inferred.json
project_categories.inferred.json  worklogs.inferred.json
project_types.inferred.json
```

# Manual QA steps
 - See testing above
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
